### PR TITLE
feat: activate the language server when a manifest is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "fmt": " tsfmt -r       && eslint -c .eslintrc.js --ext ts ./src --fix"
   },
   "activationEvents": [
-    "onLanguage:mun"
+    "onLanguage:mun",
+    "workspaceContains:**/mun.toml"
   ],
   "engines": {
     "vscode": "^1.45.1"


### PR DESCRIPTION
Activate the language server if there is a `mun.toml` manifest in the workspace.