### PR TITLE
feat: type alias

### DIFF
--- a/syntaxes/mun.tmGrammar.json
+++ b/syntaxes/mun.tmGrammar.json
@@ -125,6 +125,30 @@
 				}
 			]
 		},
+		{
+			"comment": "Type alias",
+			"begin": "\\b(type)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.mun"
+				},
+				"2": {
+					"name": "entity.name.type.mun"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#block_comment"
+				},
+				{
+					"include": "#line_comment"
+				},
+				{
+					"include": "#core_types"
+				}
+			]
+		},
         {
 			"comment": "Function call",
 			"match": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*\\(",


### PR DESCRIPTION
Adds syntax highlighting for type aliases. 

before: 
<img width="519" alt="before" src="https://user-images.githubusercontent.com/20817743/91172490-3b194f80-e717-11ea-8120-f13a9ef9098c.PNG">
after:
<img width="522" alt="after" src="https://user-images.githubusercontent.com/20817743/91172498-3e144000-e717-11ea-8dda-e7190b7e4bf7.PNG">

cc: https://github.com/mun-lang/mun/pull/251